### PR TITLE
refactor: update hsts list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ The browser now has the following information contained in the URL (Uniform Reso
 When no protocol or valid domain name is given the browser proceeds to feed the text given in the address box to the browser's default web search engine. 
 
 ## Check HSTS list (deprected)
-~~
-* The browser checks its "preloaded HSTS (HTTP Strict Transport Security)" list. This is a list of websites that have requested to be contacted via HTTPS only.
-* If the website is in the list, the browser sends its request via HTTPS instead of HTTP. Otherwise, the initial request is sent via HTTP. 
 
-Note: The website can still use the HSTS policy without being in the HSTS list. The first HTTP request to the website by a user will receive a response requesting that the user only send HTTPS requests. However, this single HTTP request could potentially leave the user vulnerable to a [downgrade attack](http://www.yourdictionary.com/downgrade-attack), which is why the HSTS list is included in modern web browsers.
+~~* The browser checks its "preloaded HSTS (HTTP Strict Transport Security)" list. This is a list of websites that have requested to be contacted via HTTPS only.
+~* If the website is in the list, the browser sends its request via HTTPS instead of HTTP. Otherwise, the initial request is sent via HTTP. 
+~
+~Note: The website can still use the HSTS policy without being in the HSTS list. The first HTTP request to the website by a user will receive a response requesting that the user only send HTTPS requests. However, this single HTTP request could potentially leave the user vulnerable to a [downgrade attack](http://www.yourdictionary.com/downgrade-attack), which is why the HSTS list is included in modern web browsers.
 ~~
+
 Modern browsers requests https first
 
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ The browser now has the following information contained in the URL (Uniform Reso
 
 When no protocol or valid domain name is given the browser proceeds to feed the text given in the address box to the browser's default web search engine. 
 
-## Check HSTS list
-
+## Check HSTS list (deprected)
+~~
 * The browser checks its "preloaded HSTS (HTTP Strict Transport Security)" list. This is a list of websites that have requested to be contacted via HTTPS only.
 * If the website is in the list, the browser sends its request via HTTPS instead of HTTP. Otherwise, the initial request is sent via HTTP. 
 
 Note: The website can still use the HSTS policy without being in the HSTS list. The first HTTP request to the website by a user will receive a response requesting that the user only send HTTPS requests. However, this single HTTP request could potentially leave the user vulnerable to a [downgrade attack](http://www.yourdictionary.com/downgrade-attack), which is why the HSTS list is included in modern web browsers.
+~~
+Modern browsers requests https first
+
 
 ## DNS lookup
 


### PR DESCRIPTION
After March 23, 2021, the majority of browsers request HTTPS at first:
https://blog.chromium.org/2021/03/a-safer-default-for-navigation-https.html